### PR TITLE
Fixing query referencing repo_feature table instead of code_feature table

### DIFF
--- a/codesurvey/database.py
+++ b/codesurvey/database.py
@@ -454,11 +454,11 @@ class Database:
         if source_names is not None:
             query = query.where(self.CodeFeatureModel.source_name.in_(source_names))
         if repo_keys is not None:
-            query = query.where(self.RepoFeatureModel.repo_key.in_(repo_keys))
+            query = query.where(self.CodeFeatureModel.repo_key.in_(repo_keys))
         if analyzer_names is not None:
             query = query.where(self.CodeFeatureModel.analyzer_name.in_(analyzer_names))
         if feature_names is not None:
-            query = query.where(self.RepoFeatureModel.feature_name.in_(feature_names))
+            query = query.where(self.CodeFeatureModel.feature_name.in_(feature_names))
 
         metadata_cache = self._get_repo_metadata_cache()
         return [


### PR DESCRIPTION
I believe the query in Database.get_code_features is incorrect, as it is running a simple query on the code_feature table, but seems to reference the repo_feature table.